### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/workstation_setup.php
+++ b/admin/workstation_setup.php
@@ -50,7 +50,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;

--- a/workstation.php
+++ b/workstation.php
@@ -77,7 +77,7 @@
 
 			case 'delete':
 				$wsp = new TWorkstationProduct;
-				$wsp->load($PDOdb, GETPOST('id_wsp'));
+				$wsp->load($PDOdb, GETPOST('id_wsp', 'int'));
 				$wsp->to_delete = true;
 				$wsp->save($PDOdb);
 
@@ -150,7 +150,7 @@
                 $ws=new TWorkstation;
                 $ws->load($PDOdb, __get('id',0,'integer'));
 
-                $ws->TWorkstationSchedule[(int)GETPOST($k)]->to_delete = true;
+                $ws->TWorkstationSchedule[GETPOST($k, 'int')]->to_delete = true;
 
                 $ws->save($PDOdb);
 

--- a/workstation.php
+++ b/workstation.php
@@ -150,7 +150,7 @@
                 $ws=new TWorkstation;
                 $ws->load($PDOdb, __get('id',0,'integer'));
 
-                $ws->TWorkstationSchedule[GETPOST($k, 'int')]->to_delete = true;
+                $ws->TWorkstationSchedule[(int)GETPOST($k, 'int')]->to_delete = true;
 
                 $ws->save($PDOdb);
 


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.