### PR TITLE
FIX tk12422 - erreur de syntax SQL lors de la validation d'un OF

### DIFF
--- a/class/workstation.class.php
+++ b/class/workstation.class.php
@@ -138,19 +138,15 @@ class TWorkstation extends TObjetStd{
 			global $db;
 
 			if(empty($this->fk_code_ws_setter)) {
-				// [FM tk12422] j'ai mis en commentaire la partie qui suit car elle provoquait une erreur SQL étant
-				// donné que le type d'événement AC_WS_SETTER n'existe nulle part et qu'on ne vérifie pas que
-				// $this->fk_code_ws_setter n'est pas vide avant de l'ajouter à la requête.
-				return array();
 
-
-				/*
 				dol_include_once('/comm/action/class/cactioncomm.class.php');
 				$cactioncomm=new CActionComm($db);
 				$cactioncomm->fetch('AC_WS_SETTER');
 
 				$this->fk_code_ws_setter = $cactioncomm->id;
-				*/
+				// [FM tk12422] le type d'événement AC_WS_SETTER n'existe pas en standard et je ne sais pas quel module
+				// le rajoute
+				if (empty($this->fk_code_ws_setter)) return array();
 			}
 
 			$date=date('Y-m-d', $time_day);

--- a/class/workstation.class.php
+++ b/class/workstation.class.php
@@ -138,12 +138,19 @@ class TWorkstation extends TObjetStd{
 			global $db;
 
 			if(empty($this->fk_code_ws_setter)) {
+				// [FM tk12422] j'ai mis en commentaire la partie qui suit car elle provoquait une erreur SQL étant
+				// donné que le type d'événement AC_WS_SETTER n'existe nulle part et qu'on ne vérifie pas que
+				// $this->fk_code_ws_setter n'est pas vide avant de l'ajouter à la requête.
+				return array();
 
+
+				/*
 				dol_include_once('/comm/action/class/cactioncomm.class.php');
 				$cactioncomm=new CActionComm($db);
 				$cactioncomm->fetch('AC_WS_SETTER');
 
 				$this->fk_code_ws_setter = $cactioncomm->id;
+				*/
 			}
 
 			$date=date('Y-m-d', $time_day);


### PR DESCRIPTION
Le type d’événement agenda `AC_WS_SETTER` n'est (pour autant que je sache) référencé nulle part ailleurs qu'ici. Peut-être dans le module gantt ? En tout cas, comme on le fetch et que ça ne retourne rien et qu'on ne vérifie pas avant de l'injecter dans le SQL, on se retrouve avec une erreur de syntaxe.

[edit]
Je viens de voir que le souci est déjà géré en 1.1. Si on merge cette PR, il faudra penser lors du merge de la 1.0 dans la 1.1 à ne pas remonter cette modif-là qui n'aura plus d'utilité.
